### PR TITLE
Add support for HTML imports

### DIFF
--- a/src/content/api.jl
+++ b/src/content/api.jl
@@ -20,15 +20,11 @@ function loadcss!(w, url)
   end
 end
 
-function importhtml!(w, file)
-  if !isurl(file)
-    resource(file)
-    file = basename(file)
-  end
+function importhtml!(w, url)
   @js_ w begin
     @var link = document.createElement("link")
     link.rel = "import"
-    link.href = $file
+    link.href = $url
     document.head.appendChild(link)
   end
 end
@@ -56,6 +52,8 @@ function load!(w, file)
     loadjs!(w, file)
   elseif ext == "css"
     loadcss!(w, file)
+  elseif ext == "html"
+    importhtml!(w, file)
   else
     error("Blink: Unsupported file type")
   end

--- a/src/content/api.jl
+++ b/src/content/api.jl
@@ -1,4 +1,4 @@
-export body!, content!, loadcss!, loadjs!, load!
+export body!, content!, loadcss!, loadjs!, load!, importhtml!
 
 content!(o, sel, html::AbstractString; fade = true) =
   fade ?
@@ -16,6 +16,19 @@ function loadcss!(w, url)
     link.type = "text/css"
     link.rel = "stylesheet"
     link.href = $url
+    document.head.appendChild(link)
+  end
+end
+
+function importhtml!(w, file)
+  if !isurl(file)
+    resource(file)
+    file = basename(file)
+  end
+  @js_ w begin
+    @var link = document.createElement("link")
+    link.rel = "import"
+    link.href = $file
     document.head.appendChild(link)
   end
 end


### PR DESCRIPTION
Hi,

I've been working on using DevTools to add rendering support for `ThreeJS` from the REPL. ThreeJS uses [HTML Imports](https://developer.mozilla.org/en-US/docs/Web/Web_Components/HTML_Imports), and I added a function to add these HTML imports and the corresponding entry given a file in Blink. This PR adds a new exported function, `importhtml!` to add this functionality.

This would be useful for things like [ThreeJS](https://github.com/rohitvarkey/ThreeJS.jl), and [Escher](https://github.com/shashi/Escher.jl) which use web components.

I wasn't sure if I should add this to the `load!` function as users might expect it to load the HTML file rather than importing it, like what `loadhtml` does.

Regards,
Rohit