### PR TITLE
Change electron call.

### DIFF
--- a/src/AtomShell/process.jl
+++ b/src/AtomShell/process.jl
@@ -37,7 +37,7 @@ end
 Shell(proc, sock) = Shell(proc, sock, Dict())
 
 @osx_only     const atom = Pkg.dir("Blink", "deps/Julia.app/Contents/MacOS/Electron")
-@linux_only   const atom = Pkg.dir("Blink", "deps/atom/atom")
+@linux_only   const atom = Pkg.dir("Blink", "deps/atom/electron")
 @windows_only const atom = Pkg.dir("Blink", "deps", "atom", "atom.exe")
 const mainjs = Pkg.dir("Blink", "src", "AtomShell", "main.js")
 


### PR DESCRIPTION
Changed how electron is called on linux in the `process.jl` file. Changed the call from `...../.julia/v0.4/Blink/deps/atom/atom` to `...../.julia/v0.4/Blink/deps/atom/electron`

Example:

```
juila> using Blink
julia> _shell = Blink.shell()
ERROR: could not spawn `/home/chase/.julia/v0.4/Blink/deps/atom/atom /home/chase/.julia/v0.4/Blink/src/AtomShell/main.js port 3371`: no such file or directory (ENOENT)
 in _jl_spawn at process.jl:262
 in anonymous at process.jl:415
 in setup_stdio at process.jl:403
 in spawn at process.jl:414
 in init at /home/chase/.julia/v0.4/Blink/src/AtomShell/process.jl:61
 in shell at /home/chase/.julia/v0.4/Blink/src/AtomShell/process.jl:102
 in get_window at /home/chase/.julia/v0.4/Plotlyjs.jl/src/display.jl:45
 in show at /home/chase/.julia/v0.4/Plotlyjs.jl/src/display.jl:52
```

The `src/deps/atom` directory didn't have `atom` in it, but it did have `electron`. Making this change allowed my computer to open an electron window.
