### PR TITLE
Add blink.js to existing page

### DIFF
--- a/res/blink.js
+++ b/res/blink.js
@@ -4,11 +4,14 @@
 
   // Comms stuff
 
-  var ws = location.href.replace("http", "ws");
-  if (!/\/\d+$/.test(ws)) {
-    ws += '/' + id;
+  var sock = {};
+  if (location.href.slice(0,16) == "http://127.0.0.1") {
+    var ws = location.href.replace("http", "ws");
+    if (!/\/\d+$/.test(ws)) {
+      ws += '/' + id;
+    }
+    var sock = new WebSocket(ws);
   }
-  var sock = new WebSocket(ws);
 
   function msg(t, m) {
     if (m === undefined) {

--- a/src/content/api.jl
+++ b/src/content/api.jl
@@ -49,14 +49,9 @@ function load!(w, file)
 end
 
 function addblink!(w)
-    @app blinkserver = (
-    Mux.defaults,
-    page("/blink.js",respond(open(readall,Pkg.dir("Blink","res","blink.js")))),
-    Mux.notfound())
-    serve(blinkserver)
-
     varid = "var id = $(w.id)"
     ws = "ws://127.0.0.1:$(Blink.port)/$(w.id)"
+    src = "http://127.0.0.1:$(Blink.port)/blink.js"
     @js_ w begin
         varid = document.createElement("script")
         varid.type = "text/javascript";
@@ -64,7 +59,7 @@ function addblink!(w)
         document.head.appendChild(varid);
         blinkjs = document.createElement("script");
         blinkjs.type = "text/javascript";
-        blinkjs.src = "http://localhost:8000/blink.js";
+        blinkjs.src = $src
         blinkjs.onload = e -> (Blink.sock = @new WebSocket($ws))
         document.head.appendChild(blinkjs);
     end

--- a/src/content/api.jl
+++ b/src/content/api.jl
@@ -47,3 +47,25 @@ function load!(w, file)
     error("Blink: Unsupported file type")
   end
 end
+
+function addblink!(w)
+    @app blinkserver = (
+    Mux.defaults,
+    page("/blink.js",respond(open(readall,Pkg.dir("Blink","res","blink.js")))),
+    Mux.notfound())
+    serve(blinkserver)
+
+    varid = "var id = $(w.id)"
+    ws = "ws://127.0.0.1:$(Blink.port)/$(w.id)"
+    @js_ w begin
+        varid = document.createElement("script")
+        varid.type = "text/javascript";
+        varid.innerText = $varid
+        document.head.appendChild(varid);
+        blinkjs = document.createElement("script");
+        blinkjs.type = "text/javascript";
+        blinkjs.src = "http://localhost:8000/blink.js";
+        blinkjs.onload = e -> (Blink.sock = @new WebSocket($ws))
+        document.head.appendChild(blinkjs);
+    end
+end

--- a/src/content/server.jl
+++ b/src/content/server.jl
@@ -62,6 +62,7 @@ http_default =
   mux(Mux.defaults,
       resroute,
       page(":id", page_handler),
+      page("/blink.js",respond(open(readall,Pkg.dir("Blink","res","blink.js")))),
       Mux.notfound())
 
 ws_default =
@@ -71,7 +72,7 @@ ws_default =
 function __init__()
   get(ENV, "BLINK_SERVE", "true") in ("1", "true") || return
   http = Mux.http_handler(Mux.App(http_default))
-  delete!(http.events, "listen")
+  # delete!(http.events, "listen")
   ws = Mux.ws_handler(Mux.App(ws_default))
   serve(Mux.Server(http, ws), port)
 end

--- a/src/content/server.jl
+++ b/src/content/server.jl
@@ -72,7 +72,6 @@ ws_default =
 function __init__()
   get(ENV, "BLINK_SERVE", "true") in ("1", "true") || return
   http = Mux.http_handler(Mux.App(http_default))
-  # delete!(http.events, "listen")
   ws = Mux.ws_handler(Mux.App(ws_default))
   serve(Mux.Server(http, ws), port)
 end


### PR DESCRIPTION
~~~julia
julia> using Blink
julia> w = Window()
julia> loadurl(w,"https://www.google.com")
julia> Blink.addblink!(w)
~~~

Adds blink.js to an existing webpage so you can interact with it form Julia.

It leaves a spurious HttpServer running, but we can close this if my [PR](https://github.com/JuliaWeb/HttpServer.jl/pull/84) is merged.

PS: I'm still learning Blink.jl, so happy to try again if there is a better way to do this.

PPS: Oh! Blink already has an HttpServer so maybe we can add a route to serve blink.js to that instead of launching a new one.

PPPS: Got it to work with the existing HttpServer. Much better. Will try again...