### PR TITLE
Add a "close" method to the API

### DIFF
--- a/src/AtomShell/window.jl
+++ b/src/AtomShell/window.jl
@@ -1,6 +1,6 @@
 using ..Blink
 import Blink: js, jsstring, id
-import Base: position, size
+import Base: position, size, close
 
 export Window, flashframe, shell, progress, title,
   centre, floating, loadurl, opentools, closetools, tools,
@@ -110,6 +110,9 @@ tools(win::Window) =
 
 front(win::Window) =
   @dot win showInactive()
+
+close(win::Window) =
+  @dot win close()
 
 # Window content APIs
 


### PR DESCRIPTION
Note that since 

~~~julia
close(w) = @dot w close
~~~

depends on @ dot, I moved api.jl to AtomShell so @ dot is defined first.

Closes #28 