### PR TITLE
Make importhtml! synchronous

### DIFF
--- a/src/content/api.jl
+++ b/src/content/api.jl
@@ -20,12 +20,25 @@ function loadcss!(w, url)
   end
 end
 
-function importhtml!(w, url)
-  @js_ w begin
-    @var link = document.createElement("link")
-    link.rel = "import"
-    link.href = $url
-    document.head.appendChild(link)
+function importhtml!(w, url; async=false)
+  if async
+    @js_ w begin
+      @var link = document.createElement("link")
+      link.rel = "import"
+      link.href = $url
+      document.head.appendChild(link)
+    end
+  else
+    @js w begin
+      @new Promise((resolve, reject) -> begin
+          @var link = document.createElement("link")
+          link.rel = "import"
+          link.href = $url
+          link.onload = (e) -> resolve(true)
+          link.onerror = (e) -> reject(false)
+          document.head.appendChild(link)
+      end)
+    end
   end
 end
 


### PR DESCRIPTION
Make use of https://github.com/JunoLab/Blink.jl/blob/master/res/blink.js#L33-L35 to block till HTML import has loaded properly. This is the default behavior of `<link rel="import" ..>` markup (I am not sure why the `appendChild` call does not block) and makes sure the components are loaded when you subsequently reference them.

cc @rohitvarkey 