### PR TITLE
Update README with install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Linux, OSX: [![Build Status](https://travis-ci.org/JunoLab/Blink.jl.svg?branch=m
 
 Blink.jl provides a API for communicating with web pages from Julia. Pages may be served over the internet and controlled from the browser, or served locally via an [Electron](https://github.com/atom/Electron) window. Blink can therefore be used as a GUI toolkit – [DevTools.jl](https://github.com/JunoLab/DevTools.jl) for an example use.
 
+To install, do:
+```julia
+Pkg.add("Blink")
+Blink.Atomshell.Install()
+```
+
 Basic usage:
 
 ```julia


### PR DESCRIPTION
I propose to add this because I didn't think of `Blink.AtomShell.install()` first. I don't think it's super obvious, so maybe you could add this to the README?