### PR TITLE
Be explicit about what to run if Electron not found

### DIFF
--- a/src/AtomShell/process.jl
+++ b/src/AtomShell/process.jl
@@ -50,7 +50,7 @@ const mainjs = resolve("Blink", "src", "AtomShell", "main.js")
 
 function electron()
   path = get(ENV, "ELECTRON_PATH", _electron)
-  isfile(path) || error("Cannot find Electron. Try `AtomShell.install()`.")
+  isfile(path) || error("Cannot find Electron. Try `Blink.AtomShell.install()`.")
   return path
 end
 


### PR DESCRIPTION
Trivial change to the error message, but I temporarily tried to do `Pkg.add("AtomShell")` before realizing that it was an internal module to Blink