### PR TITLE
Sl/propogate errors

### DIFF
--- a/res/blink.js
+++ b/res/blink.js
@@ -31,16 +31,21 @@
   function cb(id, data) {
     data === undefined && (data = null);
     Promise.resolve(data).then(data => {
-      msg('callback', {callback: id, result: data});
+      var err = data != null ? data.type == 'error' : false;
+      msg('callback', {callback: id, result: data, error: err});
     });
   }
 
   handlers.eval = function(data) {
-    var result = eval(data.code);
-    if (data.callback) {
-      result == undefined && (result = null);
-      cb(data.callback, result);
-    }
+    new Promise(resolve => resolve(eval(data.code)))
+      .catch(e => {
+        return ({type: 'error', name: e.name, message: e.message})
+      })
+      .then(result => {
+        if (data.callback) {
+          cb(data.callback, result);
+        }
+      });
   }
 
   Blink.sock = sock;


### PR DESCRIPTION
This does two things:

1. Minor fix for `jsexpr` on 0.5 where `:(x == y)` is lowered as a `:call` expr instead of `:comparison`.
2. When Julia sends code to js for evaluation, any errors on the js side are propagated back to the Julia side and throws as a `JSError`

See it in action:

```
julia> using Blink

julia> w = Window();

julia> @js w 1 + 5
6

julia> @js w 1 + foo
ERROR: Javascript error	ReferenceError: foo is not defined
 in #js#5(::Bool, ::Function, ::Blink.Page, ::Blink.JSString) at /Users/sglyon/.julia/v0.5/Blink/src/rpc/rpc.jl:41
 in (::Blink.#kw##js)(::Array{Any,1}, ::Blink.#js, ::Blink.Page, ::Blink.JSString) at ./<missing>:0
 in #js#11(::Bool, ::Function, ::Blink.AtomShell.Window, ::Blink.JSString) at /Users/sglyon/.julia/v0.5/Blink/src/AtomShell/window.jl:128
 in (::Blink.#kw##js)(::Array{Any,1}, ::Blink.#js, ::Blink.AtomShell.Window, ::Blink.JSString) at ./<missing>:0
 in js(::Blink.AtomShell.Window, ::Expr) at /Users/sglyon/.julia/v0.5/Blink/src/rpc/rpc.jl:49
```