### PR TITLE
Fix bug in Blink.msg

### DIFF
--- a/res/blink.js
+++ b/res/blink.js
@@ -11,12 +11,10 @@
   var sock = new WebSocket(ws);
 
   function msg(t, m) {
-    if (m === undefined) {
-      m = t;
-    } else {
-      m.type = t;
-    }
-    sock.send(JSON.stringify(m));
+    var msg = (m === undefined) ?
+      { type: t.type, data: t } :
+      { type: t, data: m }
+    sock.send(JSON.stringify(msg))
   }
 
   var handlers = {};

--- a/src/AtomShell/main.js
+++ b/src/AtomShell/main.js
@@ -18,7 +18,13 @@ handlers.eval = function(data, c) {
   var result = eval(data.code);
   if (data.callback) {
     result == undefined && (result = null);
-    result = {type: 'callback', callback: data.callback, result: result};
+    result = {
+      type: 'callback',
+      data: {
+        callback: data.callback,
+        result: result
+      }
+    }
     c.write(JSON.stringify(result));
   }
 }

--- a/src/content/server.jl
+++ b/src/content/server.jl
@@ -42,8 +42,8 @@ function ws_handler(req)
     try
       data = read(client)
     catch e
-      if isa(e, ArgumentError) && contains(e.msg, "closed")
-        handle_message(p, d("type"=>"close"))
+      if isa(e, ArgumentError) && contains(e.'msg, "closed")
+        handle_message(p, d("type"=>"close", "data"=>nothing))
         yield() # Prevents an HttpServer task error (!?)
         return
       else

--- a/src/rpc/callbacks.jl
+++ b/src/rpc/callbacks.jl
@@ -4,7 +4,7 @@ export handle
 
 handlers(o) = Dict()
 
-handle_message(o, m) = get(handlers(o), m["type"], identity)(m)
+handle_message(o, m) = get(handlers(o), m["type"], identity)(m["data"])
 
 handle(f, o, t) = (handlers(o)[t] = f)
 


### PR DESCRIPTION
`m.type = t` would succeed when `m` is a `String`, however JSON.stringify serializes `m` as a string losing the type field.

This PR requires "type" and "data" field in every message

fixes #65