### PR TITLE
Change to get rid of error on closing of Blink Window

### DIFF
--- a/src/content/server.jl
+++ b/src/content/server.jl
@@ -42,7 +42,7 @@ function ws_handler(req)
     try
       data = read(client)
     catch e
-      if isa(e, ArgumentError) && contains(e.'msg, "closed")
+      if isa(e, ArgumentError) && contains(e.msg, "closed")
         handle_message(p, d("type"=>"close", "data"=>nothing))
         yield() # Prevents an HttpServer task error (!?)
         return


### PR DESCRIPTION
Error generated on closing of Window, with various error messages, one
being:
WARNING: the no-op `transpose` fallback is deprecated, and no more
specific `transpose` method for ArgumentError exists. Consider
`permutedims(x, [2, 1])` or writing a specific
`transpose(x::ArgumentError)` method if appropriate.
in ws_handler(::Dict{Any,Any}) at
/Users/lwabeke/.julia/v0.5/Blink/src/content/server.jl:45