### PR TITLE
Use 0.5 instead of release on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ notifications:
 matrix:
   include:
     - os: linux
-      julia: release
+      julia: 0.5
       env: TESTCMD="xvfb-run julia"
     # - os: linux
     #   julia: nightly
     #   env: TESTCMD="xvfb-run julia"
     - os: osx
-      julia: release
+      julia: 0.5
       env: TESTCMD="julia"
     # - os: osx
     #   julia: nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5-
+julia 0.5
 WebSockets
 HttpServer
 Lazy 0.11.3


### PR DESCRIPTION
since release changes over time, but minimum supported julia version is set in REQUIRE

and remove trailing dash from julia minimum version in REQUIRE