### PR TITLE
BUG: try to fix bug with dict matching on 0.6

### DIFF
--- a/src/content/api.jl
+++ b/src/content/api.jl
@@ -48,8 +48,9 @@ function loadjs!(w, url)
     script.src = $url
     script.onload = resolve
     script.onerror = (e) -> reject(
-                               d("name"=>"JSLoadError",
-                                 "message"=>"failed to load " + this.src))
+                               Dict("name"=>"JSLoadError",
+                                    "message"=>"failed to load " + this.src)
+                                    )
     document.head.appendChild(script)
   end)
 end

--- a/src/rpc/jsexprs.jl
+++ b/src/rpc/jsexprs.jl
@@ -74,16 +74,9 @@ end
 
 function dict_expr(io, xs)
   print(io, "{")
-  xs = ["$(string(x.args[1])):"*jsexpr(x.args[2]).s for x in xs]
+  xs = [jsexpr(x).s for x in xs]
   join(io, xs, ",")
   print(io, "}")
-end
-
-function dict_expr_06(io, xs)
-    print(io, "{")
-    xs = ["$(string(x.args[2])):"*jsexpr(x.args[3]).s for x in xs]
-    join(io, xs, ",")
-    print(io, "}")
 end
 
 function if_expr(io, xs)
@@ -104,7 +97,12 @@ function jsexpr(io, x::Expr)
   isexpr(x, :block) && return block_expr(io, rmlines(x).args)
   @match x begin
     d(xs__) => dict_expr(io, xs)
-    $(Expr(:call, :Dict, :__)) => dict_expr_06(io, x.args[2:end])
+    Dict(xs__) => dict_expr(io, xs)
+    # Pairs on 0.5
+    $(Expr(:(=>), :_, :_)) => print(io, jsexpr(x.args[1]).s, ":", jsexpr(x.args[2]).s)
+
+    # Pairs on 0.6
+    $(Expr(:call, :(=>), :_, :_)) => print(io, jsexpr(x.args[2]).s, ":", jsexpr(x.args[3]).s)
     $(Expr(:comparison, :_, :(==), :_)) => jsexpr_joined(io, [x.args[1], x.args[3]], "==")  # 0.4
 
     # must include this particular `:call` expr before the catchall below

--- a/src/rpc/jsexprs.jl
+++ b/src/rpc/jsexprs.jl
@@ -79,6 +79,13 @@ function dict_expr(io, xs)
   print(io, "}")
 end
 
+function dict_expr_06(io, xs)
+    print(io, "{")
+    xs = ["$(string(x.args[2])):"*jsexpr(x.args[3]).s for x in xs]
+    join(io, xs, ",")
+    print(io, "}")
+end
+
 function if_expr(io, xs)
     if length(xs) >= 2  # we have an if
         print(io, "if (")
@@ -97,6 +104,7 @@ function jsexpr(io, x::Expr)
   isexpr(x, :block) && return block_expr(io, rmlines(x).args)
   @match x begin
     d(xs__) => dict_expr(io, xs)
+    $(Expr(:call, :Dict, :__)) => dict_expr_06(io, x.args[2:end])
     $(Expr(:comparison, :_, :(==), :_)) => jsexpr_joined(io, [x.args[1], x.args[3]], "==")  # 0.4
 
     # must include this particular `:call` expr before the catchall below

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,4 +11,6 @@ w = Window(Blink.@d(:show => false)); sleep(5.0)
 # make sure the window is really active
 @test_approx_eq @js(w, Math.log(10)) log(10)
 
+@test sprint(Blink.jsexpr, :(Dict("a" => 1, :b => 10))) == "{\"a\":1,b:10}"
+
 cleanup && AtomShell.remove()


### PR DESCRIPTION
Disclaimer: This is a total shim/hack to get PlotlyJS.jl working on 0.6.

The issue is that the MacroTools `@match` rule 

```julia
d(xs__) => dict_expr(io, xs)
```

no longer works on 0.6.

See below:

```
julia> using MacroTools

julia> ex = :(Dict("name"=>"JSLoadError", "message"=>"failed to load "))
:(Dict("name" => "JSLoadError", "message" => "failed to load "))

julia> @match ex begin
       Blink.d(xs__) => "found a dict"
       Dict(xs___) => "call dict function"
       _ => "nada"
       end

"nada"
```

I instead need to match on the Expr where we call Dict.

```
julia> @match ex begin
       Blink.d(xs__) => "found a dict"
       x_Associative => "associative"
       $(Expr(:call, :Dict, :__)) => "ugly expr call Dict"
       _ => "nada"
       end
"ugly expr call Dict"
```

So, what this does is catch that case and then hand off to a new `dict_expr_06` that properly handles expressions containing pairs.

I definitely think this can be improved upon, but for now it let's me plot on 0.6 so I'm happy ;)