### PR TITLE
Compatibility with v0.6

### DIFF
--- a/src/AtomShell/AtomShell.jl
+++ b/src/AtomShell/AtomShell.jl
@@ -2,7 +2,7 @@ module AtomShell
 
 using Compat; import Compat.String
 
-abstract Shell
+abstract type Shell end
 
 _shell = nothing
 


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/issues/20949
Got this warning during installation:
`WARNING: deprecated syntax "abstract Shell" at <>/.julia/v0.6/Blink/src/AtomShell/AtomShell.jl:6.
Use "abstract type Shell end" instead.`