### PR TITLE
Always call `evalscripts` in `fill`.

### DIFF
--- a/res/blink.js
+++ b/res/blink.js
@@ -97,17 +97,26 @@
     }
   }
 
-  function fill(node, html) {
+  function fill(node, html, fade) {
+    node = select(node);
+    fade ?
+      fillfade(node, html) :
+      fillnofade(node, html)
+  }
+  function fillfade(node, html) {
     node = select(node);
     node.classList.add('blink-show');
     callback(function () {
       node.classList.add('blink-fade');
       callback(0.2, function() {
-        node.innerHTML = html;
-        evalscripts(node);
+        fillnofade(node, html);
         node.classList.remove('blink-fade');
       });
     });
+  }
+  function fillnofade(node, html) {
+    node.innerHTML = html;
+    evalscripts(node);
   }
 
   Blink.fill = fill;

--- a/src/content/api.jl
+++ b/src/content/api.jl
@@ -1,9 +1,7 @@
 export body!, content!, loadcss!, loadjs!, load!, importhtml!
 
 content!(o, sel, html::AbstractString; fade = true) =
-  fade ?
-    @js_(o, Blink.fill($sel, $html)) :
-    @js_ o document.querySelector($sel).innerHTML = $html
+    @js_(o, Blink.fill($sel, $html, $fade))
 
 content!(o, sel, html; fade = true) =
   content!(o, sel, stringmime(MIME"text/html"(), html), fade = fade)

--- a/test/api.jl
+++ b/test/api.jl
@@ -1,0 +1,35 @@
+using Blink
+using Base.Test
+
+@testset "content! Tests" begin
+    w = Window(Blink.@d(:show => false)); sleep(5.0)
+    body!(w, ""); sleep(1.0)  # body! is not synchronous.
+    @test (@js w document.querySelector("body").innerHTML) == ""
+
+    # Test reloading body and a selector element.
+    html = """<div id="a">hi world</div><div id="b">bye</div>"""
+    body!(w, html); sleep(1.0)
+    @test (@js w document.getElementById("a").innerHTML) == "hi world"
+    @test (@js w document.getElementById("b").innerHTML) == "bye"
+    content!(w, "div", "hello world"); sleep(1.0)
+    @test (@js w document.getElementById("a").innerHTML) == "hello world"
+    # TODO(nhdaly): Is this right? Should content!(w,"div",...) change _all_ divs?
+    @test (@js w document.getElementById("b").innerHTML) == "bye"
+
+    # Test `fade` parameter and scripts:
+    fadeTestHtml = """<script>var testJS = "test";</script><div id="d">hi world</div>"""
+    @testset "Fade True" begin
+        # Must create a new window to ensure javascript is reset.
+        w = Window(Blink.@d(:show => false)); sleep(5.0)
+
+        body!(w, fadeTestHtml; fade=true); sleep(1.0)
+        @test (@js w testJS) == "test"
+    end
+    @testset "Fade False" begin
+        # Must create a new window to ensure javascript is reset.
+        w = Window(Blink.@d(:show => false)); sleep(5.0)
+
+        body!(w, fadeTestHtml; fade=false); sleep(1.0)
+        @test (@js w testJS) == "test"
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,4 +13,6 @@ w = Window(Blink.@d(:show => false)); sleep(5.0)
 
 @test sprint(Blink.jsexpr, :(Dict("a" => 1, :b => 10))) == "{\"a\":1,b:10}"
 
+include("api.jl");
+
 cleanup && AtomShell.uninstall()


### PR DESCRIPTION
Fixes #109.

Moves the fade/no-fade decision from Julia down into javascript, so that
more code can be reused whether or not `fade == true`.

This also simplifies the `content!` function body, which will make
fixing #108 a bit easier.