### PR TITLE
Test no longer needs to sleep after opening Window.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ cleanup = !AtomShell.isinstalled()
 cleanup && AtomShell.install()
 
 # open window and wait for it to initialize
-w = Window(Blink.@d(:show => false)); sleep(5.0)
+w = Window(Blink.@d(:show => false));
 
 # make sure the window is really active
 @test @js(w, Math.log(10)) ≈ log(10)


### PR DESCRIPTION
Speeds up test by removing `sleep(5.0)`.

~After #36 was submitted a couple years ago, `Window()` is synchronous,
so there's no need to `sleep()` after opening a window in the tests.~ **EDIT: jk; it was never submitted. D:**
  