### PR TITLE
bump electron version

### DIFF
--- a/src/AtomShell/install.jl
+++ b/src/AtomShell/install.jl
@@ -2,7 +2,7 @@ import BinDeps
 
 rm′(f) = (isdir(f) || isfile(f)) && rm(f, recursive = true)
 
-const version = "1.7.10"
+const version = "1.8.6"
 
 folder() = normpath(joinpath(@__FILE__, "../../../deps"))
 


### PR DESCRIPTION
The version we're using is a bit old, in particular it suffers from [this issue](https://github.com/electron/electron/issues/9860) that was only fixed in 1.8.x