### PR TITLE
add doctype html

### DIFF
--- a/src/content/main.html
+++ b/src/content/main.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <script>var id = {{id}}</script>

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,9 @@ w = Window(Blink.@d(:show => false)); sleep(5.0)
 
 @test sprint(Blink.jsexpr, :(Dict("a" => 1, :b => 10))) == "{\"a\":1,b:10}"
 
+# check that <!DOCTYPE html> was declared
+@test  startswith(Blink.maintp.tokens[1][2], "<!DOCTYPE html>\n")
+
 include("content/api.jl");
 include("AtomShell/window.jl");
 


### PR DESCRIPTION
It is needed for katex compatibility: https://techoverflow.net/2018/03/14/how-to-fix-katex-parse-error-katex-doesnt-work-in-quirks-mode/

~Not sure if the fix belongs here or in Mustache (it seems that Mustache does not create the `<!DOCTYPE html>` declaration).~

EDIT: @pfitzseb  somehow I hallucinated before and the simple fix you proposed does work (is the one in this PR)