### PR TITLE
Make body!() and content!() synchronous.

### DIFF
--- a/res/blink.js
+++ b/res/blink.js
@@ -97,26 +97,28 @@
     }
   }
 
-  function fill(node, html, fade) {
+  function fill(node, html, fade, resolve, reject) {
     node = select(node);
     fade ?
-      fillfade(node, html) :
-      fillnofade(node, html)
+      fillfade(node, html, resolve, reject) :
+      fillnofade(node, html, resolve, reject)
   }
-  function fillfade(node, html) {
+  function fillfade(node, html, resolve, reject) {
     node = select(node);
     node.classList.add('blink-show');
     callback(function () {
       node.classList.add('blink-fade');
       callback(0.2, function() {
-        fillnofade(node, html);
+        fillnofade(node, html, null, null);
         node.classList.remove('blink-fade');
+        if (resolve) resolve(true);
       });
     });
   }
-  function fillnofade(node, html) {
+  function fillnofade(node, html, resolve, reject) {
     node.innerHTML = html;
     evalscripts(node);
+    if (resolve) resolve(true);
   }
 
   Blink.fill = fill;

--- a/test/content/api.jl
+++ b/test/content/api.jl
@@ -33,3 +33,48 @@ using Base.Test
         @test (@js w testJS) == "test"
     end
 end
+
+@testset "Sync/Async content reload tests" begin
+    w = Window(Blink.@d(:show => false)); sleep(5.0)
+    sleep_content(seconds) = """
+        <script>
+            function spinsleep(ms) {
+                var start = new Date().getTime(), expire = start + ms;
+                while (new Date().getTime() < expire) { }
+                return;
+            }
+            spinsleep($(seconds * 1000));
+        </script>
+      """
+
+    @timed sleep(0.1);   # Throw-away statement to warm-up @sync and @async
+
+    x, t = @timed body!(w, sleep_content(3); fade=true, async=false)
+    #@test x == true  # TODO: What should it return?
+    @test t >= 3.0 # seconds
+
+    x, t = @timed body!(w, sleep_content(3); fade=false, async=false)
+    @test t >= 3.0 # seconds
+
+    x, t = @timed body!(w, sleep_content(3); fade=true, async=true);
+    @test t < 3.0 # seconds
+    sleep(3)  # (Wait until the end of the previous body! call.)
+
+    x, t = @timed body!(w, sleep_content(3); fade=false, async=true);
+    @test t < 3.0 # seconds
+    sleep(3)  # (Wait until the end of the previous body! call.)
+
+
+    @sync begin  # Throw-away block to warm-up @sync and @async
+        @async sleep(0.1)
+        @async sleep(0.1)
+    end
+    # Test using Julia's async mechanisms with synchronous `content!`.
+    _, t = @timed @sync begin
+      @async body!(w, sleep_content(4); async=false);
+      sleep(4)
+    end
+
+    @test t >= 4.0
+    @test t < 8
+end

--- a/test/content/api.jl
+++ b/test/content/api.jl
@@ -3,15 +3,15 @@ using Base.Test
 
 @testset "content! Tests" begin
     w = Window(Blink.@d(:show => false)); sleep(5.0)
-    body!(w, ""); sleep(1.0)  # body! is not synchronous.
+    body!(w, "", async=false);
     @test (@js w document.querySelector("body").innerHTML) == ""
 
     # Test reloading body and a selector element.
     html = """<div id="a">hi world</div><div id="b">bye</div>"""
-    body!(w, html); sleep(1.0)
+    body!(w, html, async=false);
     @test (@js w document.getElementById("a").innerHTML) == "hi world"
     @test (@js w document.getElementById("b").innerHTML) == "bye"
-    content!(w, "div", "hello world"); sleep(1.0)
+    content!(w, "div", "hello world", async=false);
     @test (@js w document.getElementById("a").innerHTML) == "hello world"
     # TODO(nhdaly): Is this right? Should content!(w,"div",...) change _all_ divs?
     @test (@js w document.getElementById("b").innerHTML) == "bye"
@@ -22,14 +22,14 @@ using Base.Test
         # Must create a new window to ensure javascript is reset.
         w = Window(Blink.@d(:show => false)); sleep(5.0)
 
-        body!(w, fadeTestHtml; fade=true); sleep(1.0)
+        body!(w, fadeTestHtml; fade=true, async=false);
         @test (@js w testJS) == "test"
     end
     @testset "Fade False" begin
         # Must create a new window to ensure javascript is reset.
         w = Window(Blink.@d(:show => false)); sleep(5.0)
 
-        body!(w, fadeTestHtml; fade=false); sleep(1.0)
+        body!(w, fadeTestHtml; fade=false, async=false);
         @test (@js w testJS) == "test"
     end
 end


### PR DESCRIPTION
Adds an option, `async` to `body!()` and `content!()`, which when `true` will
give the old behavior (return immediately), but when false, will block until
the `Window` is finished `eval`ing the javascript statement to assign the new content.

Note that this blocks until `evalscripts` has been called for all new scripts,
but that if your scripts themselves do anything asynchronous, it won't wait for
them to finish.

--------

Right now, I have `async=true` by default so that this doesn't change the
current behavior, but I really think we should set this false by default! :) If
you want, we can merge it in like this, wait for it to soak in, make sure
everyone likes the change, etc, and then flip the switch?

That said, it _shouldn't_ break anyone's code to just flip the default, it will
just likely make it a bit slower.

Part of fixing #108.