### PR TITLE
Fix Appveyor Windows test failure: win was too small

### DIFF
--- a/test/AtomShell/window.jl
+++ b/test/AtomShell/window.jl
@@ -5,6 +5,6 @@ using Base.Test
     w = Window(Blink.@d(:show => false, :width=>150, :height=>100)) ; sleep(5.0);
     @test size(w) == [150,100]
 
-    size(w, 100,200)
-    @test size(w) == [100,200]
+    size(w, 200,200)
+    @test size(w) == [200,200]
 end


### PR DESCRIPTION
This was failing on `master`, I think because windows was refusing to allow the window to be so small.