### PR TITLE
Fix tests for 0.7

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,10 +4,10 @@ module BuildBlink
 include(joinpath(@__DIR__, "../src/AtomShell/install.jl"))
 
 function get_installed_version()
-    _path = is_apple() ?
+    _path = isapple() ?
         joinpath(folder(), "version") :
         joinpath(folder(), "atom", "version")
-    strip(readstring(_path), 'v')
+    strip(read(_path, String), 'v')
 end
 
 if isinstalled() && !(version == get_installed_version())

--- a/src/AtomShell/AtomShell.jl
+++ b/src/AtomShell/AtomShell.jl
@@ -1,6 +1,8 @@
 module AtomShell
 
-using Compat; import Compat.String
+using Compat
+using Compat.Sockets
+using Compat.Sys: isapple, isunix, islinux, iswindows
 
 abstract type Shell end
 

--- a/src/AtomShell/install.jl
+++ b/src/AtomShell/install.jl
@@ -6,21 +6,21 @@ const version = "2.0.5"
 
 folder() = normpath(joinpath(@__FILE__, "../../../deps"))
 
-@static if is_apple()
+@static if isapple()
     uninstall() = map(rm′, filter(x -> !endswith(x, "build.jl"), readdir(folder())))
 else
     uninstall() = rm′(joinpath(folder(), "atom"))
 end
 
-isinstalled() = is_apple() ?
+isinstalled() = isapple() ?
     isfile(joinpath(folder(), "version")) :
     isdir(joinpath(folder(), "atom"))
 
 
 function install()
   dir = folder()
-  if is_apple()
-    const _icons = normpath(joinpath(@__FILE__, "../../../res/julia-icns.icns"))
+  if isapple()
+    _icons = normpath(joinpath(@__FILE__, "../../../res/julia-icns.icns"))
   end
   !isdir(dir) && mkpath(dir)
   uninstall()
@@ -29,7 +29,7 @@ function install()
 
     download("http://junolab.s3.amazonaws.com/blink/julia.png")
 
-    if is_apple()
+    if isapple()
       file = "electron-v$version-darwin-x64.zip"
       download("https://github.com/electron/electron/releases/download/v$version/$file")
       run(`unzip -q $file`)
@@ -41,7 +41,7 @@ function install()
       run(`touch Julia.app`)  # Apparently this is necessary to tell the OS to double-check for the new icons.
     end
 
-    if is_windows()
+    if iswindows()
       arch = Int == Int64 ? "x64" : "ia32"
       file = "electron-v$version-win32-$arch.zip"
       download("https://github.com/electron/electron/releases/download/v$version/$file")
@@ -49,7 +49,7 @@ function install()
       rm(file)
     end
 
-    if is_linux()
+    if islinux()
       arch = Int == Int64 ? "x64" : "ia32"
       file = "electron-v$version-linux-$arch.zip"
       download("https://github.com/electron/electron/releases/download/v$version/$file")

--- a/src/AtomShell/process.jl
+++ b/src/AtomShell/process.jl
@@ -3,7 +3,7 @@ using Lazy, JSON, MacroTools
 hascommand(c) =
   try read(`which $c`, String); true catch e false end
 
-spawn_rdr(cmd) = spawn(cmd, Base.spawn_opts_inherit()...)
+spawn_rdr(cmd) = run(cmd, Base.spawn_opts_inherit()...; wait=false)
 
 """
   resolve_blink_asset(path...)
@@ -81,7 +81,12 @@ function init(; debug = false)
   p, dp = port(), port()
   debug && inspector(dp)
   dbg = debug ? "--debug=$dp" : []
-  proc = (debug ? spawn_rdr : spawn)(`$(electron()) $dbg $mainjs port $p`)
+  electron_cmd = `$(electron()) $dbg $mainjs port $p`
+  proc = if debug
+    spawn_rdr(electron_cmd)
+  else
+    run(electron_cmd; wait=false)
+  end
   conn = try_connect(ip"127.0.0.1", p)
   shell = Electron(proc, conn)
   initcbs(shell)
@@ -98,9 +103,17 @@ handlers(shell::Electron) = shell.handlers
 
 function initcbs(shell)
   enable_callbacks!(shell)
-  @schedule begin
-    while active(shell)
-      @errs handle_message(shell, JSON.parse(shell.sock))
+  @static if VERSION < v"0.7.0-alpha.0"
+    @schedule begin
+      while active(shell)
+        @errs handle_message(shell, JSON.parse(shell.sock))
+      end
+    end
+  else
+    @async begin
+      while active(shell)
+        @errs handle_message(shell, JSON.parse(shell.sock))
+      end
     end
   end
 end

--- a/src/AtomShell/window.jl
+++ b/src/AtomShell/window.jl
@@ -20,17 +20,17 @@ const window_defaults = @d(:url => "about:blank",
                            :title => "Julia",
                            "node-integration" => false,
                            "use-content-size" => true,
-                           :icon => resolve("Blink", "deps", "julia.png"))
+                           :icon => resolve_blink_asset("deps", "julia.png"))
 
 raw_window(a::Electron, opts) = @js a createWindow($(merge(window_defaults, opts)))
 
-function Window(a::Shell, opts::Associative = Dict())
+function Window(a::Shell, opts::AbstractDict = Dict())
   return haskey(opts, :url) ?
     Window(raw_window(a, opts), a, nothing) :
     Window(a, Page(), opts)
 end
 
-function Window(a::Shell, content::Page, opts::Associative = Dict())
+function Window(a::Shell, content::Page, opts::AbstractDict = Dict())
   opts = merge(opts, Dict(:url => Blink.localurl(content)))
   return Window(raw_window(a, opts), a, content)
 end
@@ -120,7 +120,7 @@ close(win::Window) =
 
 # Window content APIs
 
-active(::Void) = false
+active(::Nothing) = false
 
 handlers(w::Window) = handlers(w.content)
 

--- a/src/AtomShell/window.jl
+++ b/src/AtomShell/window.jl
@@ -128,7 +128,7 @@ msg(win::Window, m) = msg(win.content, m)
 
 js(win::Window, s::JSString; callback = true) =
   active(win.content) ? js(win.content, s, callback = callback) :
-    dot(win, :(this.webContents.executeJavaScript($(jsstring(s)))), callback = callback)
+    dot(win, :(this.webContents.executeJavaScript($(s.s))), callback = callback)
 
 const initcss = """
   <style>html,body{margin:0;padding:0;border:0;text-align:center;}</style>

--- a/src/AtomShell/window.jl
+++ b/src/AtomShell/window.jl
@@ -7,7 +7,7 @@ export Window, flashframe, shell, progress, title,
   centre, floating, loadurl, opentools, closetools, tools,
   loadhtml, loadfile, css, front
 
-type Window
+mutable struct Window
   id::Int
   shell::Shell
   content
@@ -141,6 +141,10 @@ function loadhtml(win::Window, html::AbstractString)
     println(io, html)
   end
   loadfile(win, tmp)
-  @schedule (sleep(1); rm(tmp))
+  @static if VERSION < v"0.7.0-alpha.0"
+    @schedule (sleep(1); rm(tmp))
+  else
+    @async (sleep(1); rm(tmp))
+  end
   return
 end

--- a/src/Blink.jl
+++ b/src/Blink.jl
@@ -7,6 +7,7 @@ using Compat
 using Compat.Distributed: Future
 using Compat.Sys: isunix, islinux, isapple, iswindows
 using Compat.Sockets
+using Compat.Base64: stringmime
 
 include("rpc/rpc.jl")
 include("content/content.jl")

--- a/src/Blink.jl
+++ b/src/Blink.jl
@@ -3,7 +3,10 @@ __precompile__()
 module Blink
 
 using Reexport
-using Compat; import Compat.String
+using Compat
+using Compat.Distributed: Future
+using Compat.Sys: isunix, islinux, isapple, iswindows
+using Compat.Sockets
 
 include("rpc/rpc.jl")
 include("content/content.jl")
@@ -11,6 +14,6 @@ include("content/content.jl")
 include("AtomShell/AtomShell.jl")
 export AtomShell
 @reexport using .AtomShell
-import .AtomShell: resolve
+import .AtomShell: resolve_blink_asset
 
 end # module

--- a/src/content/config.jl
+++ b/src/content/config.jl
@@ -1,6 +1,8 @@
 export localips
 
-@init global const port = get(ENV, "BLINK_PORT", rand(2_000:10_000))
+const port = Ref{Int}()
+
+@init port[] = haskey(ENV, "BLINK_PORT") ? parse(Int, get(ENV, "BLINK_PORT")) : rand(2_000:10_000)
 
 const ippat = r"([0-9]+\.){3}[0-9]+"
 
@@ -21,6 +23,6 @@ elseif iswindows()
     launch(x) = run(`cmd /C start $x`)
 end
 
-localurl(p::Page) = "http://127.0.0.1:$port/$(id(p))"
+localurl(p::Page) = "http://127.0.0.1:$(port[])/$(id(p))"
 
 launch(p::Page) = (launch(localurl(p)); p)

--- a/src/content/config.jl
+++ b/src/content/config.jl
@@ -4,7 +4,7 @@ export localips
 
 const ippat = r"([0-9]+\.){3}[0-9]+"
 
-@static if is_unix()
+@static if isunix()
     localips() = map(IPv4, readlines(`ifconfig` |>
                       `grep -Eo $("inet (addr:)?$(ippat.pattern)")` |>
                       `grep -Eo $(ippat.pattern)` |>
@@ -13,11 +13,11 @@ end
 
 # Browser Window
 
-@static if is_apple()
+@static if isapple()
     launch(x) = run(`open $x`)
-elseif is_linux()
+elseif islinux()
     launch(x) = run(`xdg-open $x`)
-elseif is_windows()
+elseif iswindows()
     launch(x) = run(`cmd /C start $x`)
 end
 

--- a/src/content/content.jl
+++ b/src/content/content.jl
@@ -20,7 +20,9 @@ mutable struct Page
     init == nothing || (p.handlers["init"] = init)
     enable_callbacks!(p)
     pool[p.id] = WeakRef(p)
-    finalizer(p, p -> delete!(pool, p.id))
+    finalizer(p) do p
+      delete!(pool, p.id)
+    end
     return p
   end
 end

--- a/src/content/content.jl
+++ b/src/content/content.jl
@@ -6,7 +6,7 @@ include("api.jl")
 
 # Content
 
-type Page
+mutable struct Page
   id::Int
   sock::WebSocket
   handlers::Dict{String, Any}
@@ -52,5 +52,5 @@ end
 include("server.jl")
 
 @init for r in ["blink.js", "blink.css", "reset.css", "spinner.css"]
-  resource(resolve("Blink", "res", r))
+  resource(resolve_blink_asset("res", r))
 end

--- a/src/content/server.jl
+++ b/src/content/server.jl
@@ -16,7 +16,7 @@ const maintp = Mustache.template_from_file(joinpath(dirname(@__FILE__), "main.ht
 app(f) = req -> render(maintp, d("id"=>Page(f).id))
 
 function page_handler(req)
-  id = try parse(req[:params][:id]) catch e @goto fail end
+  id = try parse(Int, req[:params][:id]) catch e @goto fail end
   haskey(pool, id) || @goto fail
   active(pool[id].value) && @goto fail
 
@@ -28,14 +28,14 @@ function page_handler(req)
 end
 
 function ws_handler(req)
-  id = try parse(req[:path][end]) catch e @goto fail end
+  id = try parse(Int, req[:path][end]) catch e @goto fail end
   client = req[:socket]
   haskey(pool, id) || @goto fail
   p = pool[id].value
   active(p) && @goto fail
 
   p.sock = client
-  @schedule @errs get(handlers(p), "init", identity)(p)
+  @async @errs get(handlers(p), "init", identity)(p)
   put!(p.cb, true)
   while active(p)
     local data
@@ -79,5 +79,5 @@ function serve()
   http = Mux.http_handler(Mux.App(http_default))
   #delete!(http.events, "listen")
   ws = Mux.ws_handler(Mux.App(ws_default))
-  @async WebSockets.serve(WebSockets.ServerWS(http, ws), ip"127.0.0.1", port, false)
+  @async WebSockets.serve(WebSockets.ServerWS(http, ws), ip"127.0.0.1", port[], false)
 end

--- a/src/content/server.jl
+++ b/src/content/server.jl
@@ -77,7 +77,7 @@ function serve()
   serving && return
   serving = true
   http = Mux.http_handler(Mux.App(http_default))
-  delete!(http.events, "listen")
+  #delete!(http.events, "listen")
   ws = Mux.ws_handler(Mux.App(ws_default))
-  Mux.serve(Mux.Server(http, ws), port, host = ip"127.0.0.1")
+  @async WebSockets.serve(WebSockets.ServerWS(http, ws), ip"127.0.0.1", 8080, false)
 end

--- a/src/content/server.jl
+++ b/src/content/server.jl
@@ -79,5 +79,5 @@ function serve()
   http = Mux.http_handler(Mux.App(http_default))
   #delete!(http.events, "listen")
   ws = Mux.ws_handler(Mux.App(ws_default))
-  @async WebSockets.serve(WebSockets.ServerWS(http, ws), ip"127.0.0.1", 8080, false)
+  @async WebSockets.serve(WebSockets.ServerWS(http, ws), ip"127.0.0.1", port, false)
 end

--- a/src/rpc/rpc.jl
+++ b/src/rpc/rpc.jl
@@ -7,7 +7,7 @@ export js, @js, @js_, @var, @new
 
 include("callbacks.jl")
 
-type JSError <: Exception
+mutable struct JSError <: Exception
     name::String
     msg::String
 end
@@ -32,7 +32,7 @@ function js(o, js::JSString; callback = true)
 
   if callback
       val = wait(cond)
-      if isa(val, Associative) && get(val, "type", "") == "error"
+      if isa(val, AbstractDict) && get(val, "type", "") == "error"
           err = JSError(get(val, "name", "unknown"), get(val, "message", "blank"))
           throw(err)
       end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Blink
-using Base.Test
+using Compat.Test
+using Compat.Sockets
+
 
 cleanup = !AtomShell.isinstalled()
 


### PR DESCRIPTION
Working on this 
```
[ Info: Listening on: Sockets.InetAddr{IPv4}(ip"127.0.0.1", 0x1f90)
Error During Test at /Users/vdayanan/.julia/dev/Blink/test/runtests.jl:14
  Test threw exception MethodError(isapprox, (Dict{String,Any}(), 2.302585092994046), 0x0000000000006bdb)
  Expression: #= /Users/vdayanan/.julia/dev/Blink/test/runtests.jl:14 =# @js(w, Math.log(10)) ≈ log(10)
  MethodError: no method matching isapprox(::Dict{String,Any}, ::Float64)
  Closest candidates are:
    isapprox(!Matched::Number, ::Number; atol, rtol, nans) at floatfuncs.jl:259
  Stacktrace:
   [1] eval_test(::Expr, ::Expr, ::LineNumberNode) at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v0.7/Test/src/Test.jl:226
   [2] top-level scope at none:0
   [3] include at ./boot.jl:317 [inlined]
   [4] include_relative(::Module, ::String) at ./loading.jl:1034
   [5] include(::Module, ::String) at ./sysimg.jl:29
   [6] include(::String) at ./client.jl:393
   [7] top-level scope at none:0
   [8] eval(::Module, ::Any) at ./boot.jl:319
   [9] exec_options(::Base.JLOptions) at ./logging.jl:305
   [10] _start() at ./client.jl:427
ERROR: LoadError: There was an error during testing
in expression starting at /Users/vdayanan/.julia/dev/Blink/test/runtests.jl:14
ERROR: Package Blink errored during testing
```