### PR TITLE
Change `is_<os>` to `Sys.is<os>`

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,7 +4,7 @@ module BuildBlink
 include(joinpath(@__DIR__, "../src/AtomShell/install.jl"))
 
 function get_installed_version()
-    _path = is_apple() ?
+    _path = Sys.isapple() ?
         joinpath(folder(), "version") :
         joinpath(folder(), "atom", "version")
     strip(readstring(_path), 'v')

--- a/src/AtomShell/install.jl
+++ b/src/AtomShell/install.jl
@@ -6,22 +6,21 @@ const version = "2.0.5"
 
 folder() = normpath(joinpath(@__FILE__, "../../../deps"))
 
-@static if is_apple()
+@static if Sys.isapple()
     uninstall() = map(rm′, filter(x -> !endswith(x, "build.jl"), readdir(folder())))
 else
     uninstall() = rm′(joinpath(folder(), "atom"))
 end
 
-isinstalled() = is_apple() ?
+isinstalled() = Sys.isapple() ?
     isfile(joinpath(folder(), "version")) :
     isdir(joinpath(folder(), "atom"))
 
 
 function install()
   dir = folder()
-  if is_apple()
-    const _icons = normpath(joinpath(@__FILE__, "../../../res/julia-icns.icns"))
-  end
+  _icons = Sys.isapple() ? normpath(joinpath(@__FILE__, "../../../res/julia-icns.icns")) : nothing
+
   !isdir(dir) && mkpath(dir)
   uninstall()
   cd(dir) do
@@ -29,7 +28,7 @@ function install()
 
     download("http://junolab.s3.amazonaws.com/blink/julia.png")
 
-    if is_apple()
+    if Sys.isapple()
       file = "electron-v$version-darwin-x64.zip"
       download("https://github.com/electron/electron/releases/download/v$version/$file")
       run(`unzip -q $file`)
@@ -41,7 +40,7 @@ function install()
       run(`touch Julia.app`)  # Apparently this is necessary to tell the OS to double-check for the new icons.
     end
 
-    if is_windows()
+    if Sys.iswindows()
       arch = Int == Int64 ? "x64" : "ia32"
       file = "electron-v$version-win32-$arch.zip"
       download("https://github.com/electron/electron/releases/download/v$version/$file")
@@ -49,7 +48,7 @@ function install()
       rm(file)
     end
 
-    if is_linux()
+    if Sys.islinux()
       arch = Int == Int64 ? "x64" : "ia32"
       file = "electron-v$version-linux-$arch.zip"
       download("https://github.com/electron/electron/releases/download/v$version/$file")

--- a/src/AtomShell/process.jl
+++ b/src/AtomShell/process.jl
@@ -39,11 +39,11 @@ end
 
 Electron(proc, sock) = Electron(proc, sock, Dict())
 
-@static if is_apple()
+@static if Sys.isapple()
   const _electron = resolve("Blink", "deps/Julia.app/Contents/MacOS/Julia")
-elseif is_linux()
+elseif Sys.islinux()
   const _electron = resolve("Blink", "deps/atom/electron")
-elseif is_windows()
+elseif Sys.iswindows()
   const _electron = resolve("Blink", "deps", "atom", "electron.exe")
 end
 const mainjs = resolve("Blink", "src", "AtomShell", "main.js")

--- a/src/content/config.jl
+++ b/src/content/config.jl
@@ -4,7 +4,7 @@ export localips
 
 const ippat = r"([0-9]+\.){3}[0-9]+"
 
-@static if is_unix()
+@static if Sys.isunix()
     localips() = map(IPv4, readlines(`ifconfig` |>
                       `grep -Eo $("inet (addr:)?$(ippat.pattern)")` |>
                       `grep -Eo $(ippat.pattern)` |>
@@ -13,11 +13,11 @@ end
 
 # Browser Window
 
-@static if is_apple()
+@static if Sys.isapple()
     launch(x) = run(`open $x`)
-elseif is_linux()
+elseif Sys.islinux()
     launch(x) = run(`xdg-open $x`)
-elseif is_windows()
+elseif Sys.iswindows()
     launch(x) = run(`cmd /C start $x`)
 end
 


### PR DESCRIPTION
[JuliaLang/julia#22182](https://github.com/JuliaLang/julia/pull/22182) deprecates `is_linux`, `is_windows` etc in favour of `Sys.islinux`, `Sys.iswindows` etc.

Also fixes one line where a local variable was declared `const`.

I can't really test this atm though, because I don't get some dependencies to build properly yet.