### PR TITLE
Fix broken test: update test of Mustache token value

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ w = Window(Blink.@d(:show => false)); sleep(10.0)
 @test string(Blink.jsstring(:(Dict("a" => 1, :b => 10)))...) == "{\"a\":1,\"b\":10}"
 
 # check that <!DOCTYPE html> was declared
-@test  startswith(Blink.maintp.tokens[1][2], "<!DOCTYPE html>\n")
+@test  startswith(Blink.maintp.tokens[1].value, "<!DOCTYPE html>\n")
 
 include("content/api.jl");
 include("AtomShell/window.jl");


### PR DESCRIPTION
Test is broken on master, but this fixes it. It looks like we were broken by
this recent Mustache change:
https://github.com/jverzani/Mustache.jl/releases/tag/v0.5.0