### PR TITLE
Fix 0.7 deprecations for 1.0 support

### DIFF
--- a/src/content/api.jl
+++ b/src/content/api.jl
@@ -63,7 +63,7 @@ function loadjs!(w, url)
   end)
 end
 
-isurl(f) = ismatch(r"^https?://", f)
+isurl(f) = occursin(r"^https?://", f)
 
 function load!(w, file; async=false)
   if !isurl(file)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,16 +7,18 @@ cleanup = !AtomShell.isinstalled()
 
 cleanup && AtomShell.install()
 
-# open window and wait for it to initialize
-w = Window(Blink.@d(:show => false), async=false);
+@testset "basic functionality" begin
+    # open window and wait for it to initialize
+    w = Window(Blink.@d(:show => false), async=false);
 
-# make sure the window is really active
-@test @js(w, Math.log(10)) ≈ log(10)
+    # make sure the window is really active
+    @test @js(w, Math.log(10)) ≈ log(10)
 
-@test string(Blink.jsstring(:(Dict("a" => 1, :b => 10)))...) == "{\"a\":1,\"b\":10}"
+    @test string(Blink.jsstring(:(Dict("a" => 1, :b => 10)))...) == "{\"a\":1,\"b\":10}"
 
-# check that <!DOCTYPE html> was declared
-@test  startswith(Blink.maintp.tokens[1].value, "<!DOCTYPE html>\n")
+    # check that <!DOCTYPE html> was declared
+    @test  startswith(Blink.maintp.tokens[1].value, "<!DOCTYPE html>\n")
+end
 
 include("content/api.jl");
 include("AtomShell/window.jl");


### PR DESCRIPTION
- s/ismatch/occursin
- fix deprecations in test/ files: wrap basic tests in their own @testset so `w` isn't a global.