### PR TITLE
Fix incorrect get(ENV, ...)

### DIFF
--- a/src/content/config.jl
+++ b/src/content/config.jl
@@ -2,7 +2,7 @@ export localips
 
 const port = Ref{Int}()
 
-@init port[] = haskey(ENV, "BLINK_PORT") ? parse(Int, get(ENV, "BLINK_PORT")) : rand(2_000:10_000)
+@init port[] = get(ENV, "BLINK_PORT", rand(2_000:10_000))
 
 const ippat = r"([0-9]+\.){3}[0-9]+"
 

--- a/src/content/config.jl
+++ b/src/content/config.jl
@@ -2,7 +2,7 @@ export localips
 
 const port = Ref{Int}()
 
-@init port[] = get(ENV, "BLINK_PORT", rand(2_000:10_000))
+@init port[] = haskey(ENV, "BLINK_PORT") ? parse(Int, ENV["BLINK_PORT"]) : rand(2_000:10_000)
 
 const ippat = r"([0-9]+\.){3}[0-9]+"
 


### PR DESCRIPTION
Currently, we use `haskey(ENV, "key") ? get(ENV, "key") : "default value"` which isn't a valid usage of `get` and thus results in an error whenever `BLINK_PORT` is set.