### PR TITLE
Merge the webio dep code in Blink

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -7,5 +7,5 @@ Mustache
 MacroTools
 Mux
 BinDeps
-WebIO 0.3
+WebIO 0.4.0
 JSExpr 0.3

--- a/REQUIRE
+++ b/REQUIRE
@@ -9,3 +9,4 @@ Mux
 BinDeps
 WebIO 0.4.0
 JSExpr 0.3
+AssetRegistry

--- a/res/webio_setup.js
+++ b/res/webio_setup.js
@@ -1,0 +1,14 @@
+(function (Blink) {
+    if (Blink.sock) {
+        WebIO.sendCallback = function (msg) {
+            Blink.msg("webio", msg);
+        }
+        WebIO.triggerConnected();
+    } else {
+        console.error("Blink not connected")
+    }
+
+    Blink.handlers.webio = function (msg) {
+        WebIO.dispatch(msg.data);
+    };
+})(Blink);

--- a/src/Blink.jl
+++ b/src/Blink.jl
@@ -16,4 +16,7 @@ export AtomShell
 @reexport using .AtomShell
 import .AtomShell: resolve_blink_asset
 
+import WebIO: AbstractWidget
+include("webio.jl")
+
 end # module

--- a/src/Blink.jl
+++ b/src/Blink.jl
@@ -16,6 +16,10 @@ export AtomShell
 @reexport using .AtomShell
 import .AtomShell: resolve_blink_asset
 
+for r in ["blink.js", "blink.css", "reset.css", "spinner.css"]
+  resource(resolve_blink_asset("res", r))
+end
+
 import WebIO: AbstractWidget
 include("webio.jl")
 

--- a/src/content/content.jl
+++ b/src/content/content.jl
@@ -53,6 +53,3 @@ end
 
 include("server.jl")
 
-@init for r in ["blink.js", "blink.css", "reset.css", "spinner.css"]
-  resource(resolve_blink_asset("res", r))
-end

--- a/src/content/server.jl
+++ b/src/content/server.jl
@@ -11,7 +11,8 @@ const resroute =
 
 # Server setup
 
-const maintp = Mustache.template_from_file(joinpath(dirname(@__FILE__), "main.html"))
+const mainhtml = joinpath(dirname(@__FILE__), "main.html")
+const maintp = Mustache.template_from_file(mainhtml)
 
 app(f) = req -> render(maintp, d("id"=>Page(f).id))
 

--- a/src/webio.jl
+++ b/src/webio.jl
@@ -5,9 +5,6 @@ using WebIO
 const blinksetup = joinpath(dirname(@__FILE__), "..",
                             "res", 
                             "webio_setup.js")
-@show blinksetup
-@show isfile(blinksetup)
-
 using Sockets
 
 struct BlinkConnection <: WebIO.AbstractConnection

--- a/src/webio.jl
+++ b/src/webio.jl
@@ -2,7 +2,7 @@ using AssetRegistry
 using Base64: stringmime
 using WebIO
 
-const blinksetup = joinpath(dirname(@__FILE__), "..",
+const webiosetup = joinpath(dirname(@__FILE__), "..",
                             "res", 
                             "webio_setup.js")
 using Sockets
@@ -15,7 +15,7 @@ function Blink.body!(p::Blink.Page, x::Union{Node, Scope, AbstractWidget})
     wait(p)
 
     bp = AssetRegistry.register(WebIO.bundlepath)
-    bs = AssetRegistry.register(blinksetup)
+    bs = AssetRegistry.register(webiosetup)
 
     Blink.loadjs!(p, bp)
     Blink.loadjs!(p, bs)

--- a/src/webio.jl
+++ b/src/webio.jl
@@ -1,0 +1,50 @@
+using AssetRegistry
+using Base64: stringmime
+using WebIO
+
+const blinksetup = joinpath(dirname(@__FILE__), "..",
+                            "res", 
+                            "webio_setup.js")
+@show blinksetup
+@show isfile(blinksetup)
+
+using Sockets
+
+struct BlinkConnection <: WebIO.AbstractConnection
+    page::Blink.Page
+end
+
+function Blink.body!(p::Blink.Page, x::Union{Node, Scope, AbstractWidget})
+    wait(p)
+
+    bp = AssetRegistry.register(WebIO.bundlepath)
+    bs = AssetRegistry.register(blinksetup)
+
+    Blink.loadjs!(p, bp)
+    Blink.loadjs!(p, bs)
+
+    conn = BlinkConnection(p)
+    Blink.handle(p, "webio") do msg
+        WebIO.dispatch(conn, msg)
+    end
+
+    Blink.body!(p, stringmime(MIME"text/html"(), x))
+end
+
+function Blink.body!(p::Blink.Window, x::Union{Node, Scope, AbstractWidget})
+    Blink.body!(p.content, x)
+end
+
+function Sockets.send(b::BlinkConnection, data)
+    Blink.msg(b.page, Dict(:type=>"webio", :data=>data))
+end
+
+Base.isopen(b::BlinkConnection) = Blink.active(b.page)
+
+function WebIO.register_renderable(T::Type, ::Val{:blink})
+    eval(:(Blink.body!(p::Union{Blink.Window, Blink.Page}, x::$T) =
+           Blink.body!(p, WebIO.render(x))))
+end
+
+WebIO.setup_provider(::Val{:blink}) = nothing  # blink setup has no side-effects
+WebIO.setup(:blink)


### PR DESCRIPTION
Currently WebIO uses Requires.jl to interface with Blink. However, we currently can't statically compile packages that use Requires.jl. 

This helps support for shipping statically compiled Blink apps.