### PR TITLE
Automatically install Electron when building Blink

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,7 +10,7 @@ function get_installed_version()
     strip(read(_path, String), 'v')
 end
 
-if isinstalled() && !(version == get_installed_version())
+if !isinstalled() || version != get_installed_version()
     install()
 end
 


### PR DESCRIPTION
`] build Blink` now installs Electron the first time, and any time the electron version is updated in the code but not in the installed version.

Closes https://github.com/JunoLab/Blink.jl/issues/170