### PR TITLE
Use 7z.exe from Julia binary download

### DIFF
--- a/src/AtomShell/install.jl
+++ b/src/AtomShell/install.jl
@@ -46,7 +46,7 @@ function install()
        file = "electron-v$version-win32-$arch.zip"
        download("https://github.com/electron/electron/releases/download/v$version/$file")
        zipper = joinpath(Base.Sys.BINDIR, "7z.exe")
-        if !isfile(zipper)
+       if !isfile(zipper)
            #=
            This is likely built with cygwin, which includes its own version of 7z.
            But if we unzip with cmd = Cmd(`$(fwhich("bash.exe")) 7z x $file -oatom`)
@@ -67,7 +67,6 @@ function install()
         cmd = Cmd([zipper, "x", file, "-oatom"])
         run(cmd)
         rm(file)
-      end
     end
 
     if Sys.islinux()


### PR DESCRIPTION
Ref. issue #148
modified:   src/AtomShell/install.jl

Use (julia)/bin/7z.exe for unpacking. This is not available in home-built Julia. If so, it looks for the latest binary download folder (assuming the installation was not made for all users).

Using home-built-Julia is a prerequisite to using > 4 cores, or due to a known bug, things like 
```
using Logging
@edit Logging.ConsoleLogger()
```
