### PR TITLE
Fix travis.yml to run tests & coverage after Documentation changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ script:
 jobs:
   include:
     - stage: "test"
-      include:
-    - os: linux
+      os: linux
       julia: 0.7
       env: TESTCMD="xvfb-run julia"
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,34 +2,39 @@ language: julia
 notifications:
   email: false
 
-matrix:
-  include:
-    - os: linux
-      julia: 0.7
-      env: TESTCMD="xvfb-run julia"
-    - os: linux
-      julia: 1.0
-      env: TESTCMD="xvfb-run julia"
-    - os: linux
-      julia: nightly
-      env: TESTCMD="xvfb-run julia"
-    - os: osx
-      julia: 0.7
-      env: TESTCMD="julia"
-    - os: osx
-      julia: 1.0
-      env: TESTCMD="julia"
-    - os: osx
-      julia: nightly
-      env: TESTCMD="julia"
-  allow_failures:
-    - julia: nightly
-branches:
-  only:
-    - master
-
 script:
   - $TESTCMD --color=yes -e "using Pkg; Pkg.clone(pwd()); Pkg.build(\"Blink\"); Pkg.test(\"Blink\"; coverage=true)"
+
+jobs:
+  include:
+    - stage: "test"
+      include:
+    - os: linux
+      julia: 0.7
+      env: TESTCMD="xvfb-run julia"
+    - os: linux
+      julia: 1.0
+      env: TESTCMD="xvfb-run julia"
+    - os: linux
+      julia: nightly
+      env: TESTCMD="xvfb-run julia"
+    - os: osx
+      julia: 0.7
+      env: TESTCMD="julia"
+    - os: osx
+      julia: 1.0
+      env: TESTCMD="julia"
+    - os: osx
+      julia: nightly
+      env: TESTCMD="julia"
+
+    - stage: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs/ --color=yes -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
+        - julia --project=docs/ --color=yes docs/make.jl
+      after_success: skip
 
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder()); Coveralls.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,26 @@ language: julia
 notifications:
   email: false
 
-os:
-  - linux
-    env: TESTCMD="xvfb-run julia"
-  - osx
-    env: TESTCMD="julia"
-
-julia:
-  - 0.7
-  - 1.0
-  - nightly
-
 matrix:
+  include:
+    - os: linux
+      julia: 0.7
+      env: TESTCMD="xvfb-run julia"
+    - os: linux
+      julia: 1.0
+      env: TESTCMD="xvfb-run julia"
+    - os: linux
+      julia: nightly
+      env: TESTCMD="xvfb-run julia"
+    - os: osx
+      julia: 0.7
+      env: TESTCMD="julia"
+    - os: osx
+      julia: 1.0
+      env: TESTCMD="julia"
+    - os: osx
+      julia: nightly
+      env: TESTCMD="julia"
   allow_failures:
     - julia: nightly
 branches:
@@ -25,13 +33,3 @@ script:
 
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder()); Coveralls.submit(process_folder())'
-
-jobs:
-  include:
-    - stage: "Documentation"
-      julia: 1.0
-      os: linux
-      script:
-        - julia --project=docs/ --color=yes -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
-        - julia --project=docs/ --color=yes docs/make.jl
-      after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,9 @@ branches:
   only:
     - master
 script:
-  - $TESTCMD --color=yes -e "VERSION >= v\"0.7.0-DEV.5183\" && using Pkg; Pkg.clone(pwd()); Pkg.build(\"Blink\"); Pkg.test(\"Blink\"; coverage=true)"
+  - $TESTCMD --color=yes -e "using Pkg; Pkg.clone(pwd()); Pkg.build(\"Blink\"); Pkg.test(\"Blink\"; coverage=true)"
+after_success:
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder()); Coveralls.submit(process_folder())'
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       os: linux
       script:
         - julia --project=docs/ --color=yes -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
-        - julia --project=docs/ --color=yes docs/make.jl
+        - xvfb-run julia --project=docs/ --color=yes docs/make.jl
       after_success: skip
   allow_failures:
     - julia: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: julia
 notifications:
   email: false
 
-script:
-  - $TESTCMD --color=yes -e "using Pkg; Pkg.clone(pwd()); Pkg.build(\"Blink\"); Pkg.test(\"Blink\"; coverage=true)"
-
-jobs:
+matrix:
   include:
     - stage: "test"
       os: linux
@@ -34,6 +31,13 @@ jobs:
         - julia --project=docs/ --color=yes -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
         - julia --project=docs/ --color=yes docs/make.jl
       after_success: skip
+  allow_failures:
+    - julia: nightly
+branches:
+  only:
+    - master
+script:
+  - $TESTCMD --color=yes -e "using Pkg; Pkg.clone(pwd()); Pkg.build(\"Blink\"); Pkg.test(\"Blink\"; coverage=true)"
 
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder()); Coveralls.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,28 @@
 language: julia
 notifications:
   email: false
+
+os:
+  - linux
+    env: TESTCMD="xvfb-run julia"
+  - osx
+    env: TESTCMD="julia"
+
+julia:
+  - 0.7
+  - 1.0
+  - nightly
+
 matrix:
-  include:
-    - os: linux
-      julia: 0.7
-      env: TESTCMD="xvfb-run julia"
-    - os: linux
-      julia: 1.0
-      env: TESTCMD="xvfb-run julia"
-    - os: linux
-      julia: nightly
-      env: TESTCMD="xvfb-run julia"
-    - os: osx
-      julia: 0.7
-      env: TESTCMD="julia"
-    - os: osx
-      julia: 1.0
-      env: TESTCMD="julia"
-    - os: osx
-      julia: nightly
-      env: TESTCMD="julia"
   allow_failures:
     - julia: nightly
 branches:
   only:
     - master
+
 script:
   - $TESTCMD --color=yes -e "using Pkg; Pkg.clone(pwd()); Pkg.build(\"Blink\"); Pkg.test(\"Blink\"; coverage=true)"
+
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder()); Coveralls.submit(process_folder())'
 


### PR DESCRIPTION
I think we broke travis a bit during the manual commits to master between #173 and  #176:
https://github.com/JunoLab/Blink.jl/compare/279797f..d428434

Looking at the latest builds, it doesn't seem to actually be running the tests! 😱
Also, we accidentally deleted the `after_success` `Coverage` section, so i've added that back. I'm still not sure what caused the Tests to stop running, but i'm looking into it!