### PR TITLE
bump electron version

### DIFF
--- a/src/AtomShell/install.jl
+++ b/src/AtomShell/install.jl
@@ -2,7 +2,7 @@ import BinDeps
 
 rm′(f) = (isdir(f) || isfile(f)) && rm(f, recursive = true)
 
-const version = "2.0.8"
+const version = "4.0.4"
 
 folder() = normpath(joinpath(@__FILE__, "../../../deps"))
 

--- a/src/AtomShell/install.jl
+++ b/src/AtomShell/install.jl
@@ -2,7 +2,7 @@ import BinDeps
 
 rm′(f) = (isdir(f) || isfile(f)) && rm(f, recursive = true)
 
-const version = "2.0.5"
+const version = "2.0.8"
 
 folder() = normpath(joinpath(@__FILE__, "../../../deps"))
 


### PR DESCRIPTION
According to https://github.com/Microsoft/vscode/issues/57776#issuecomment-419942687 the incompatibility of Electron with Ubuntu 18.10 reported in #184 was fixed in Electron 2.0.8 so I'm bumping the minor version (I'm doing the most conservative upgrade). This fixes it at least on my machine.