### PR TITLE
Increase the try_connect timeout

### DIFF
--- a/src/AtomShell/process.jl
+++ b/src/AtomShell/process.jl
@@ -73,7 +73,7 @@ end
 
 port() = rand(2_000:10_000)
 
-function try_connect(args...; interval = 0.01, attempts = 300)
+function try_connect(args...; interval = 0.01, attempts = 500)
   for i = 1:attempts
     try
       return connect(args...)


### PR DESCRIPTION
A timeout of ~3 seconds is too quick when an X11 window is forwarded over SSH.  Yeah, Electron with a remote X11 window is pretty slow to use, but it's handy at times.  In my case, extending it to ~4 seconds was sufficient.  I've extended it to 5 seconds just to be safe for folks with slower connections.