### PR TITLE
Fix WebIO integration, make Window's sync by default.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ end
 
 include("content/api.jl");
 include("AtomShell/window.jl");
+include("./webio.jl")
 
 if Sys.iswindows()
     # Uninstalling AtomShell on Windows is currently broken:

--- a/test/webio.jl
+++ b/test/webio.jl
@@ -1,0 +1,59 @@
+using Test
+using Blink
+using WebIO
+
+"""
+Execute function f() with a timeout of `timeout` seconds. Returns the
+result of f() or `nothing` in the case of a timeout.
+"""
+function with_timeout(f::Function, timeout)
+    c = Channel{Any}(1)
+    @async begin
+        put!(c, f())
+    end
+    @async begin
+        sleep(timeout)
+        put!(c, nothing)
+    end
+    take!(c)
+end
+
+@testset "WebIO integration" begin
+    @testset "mount test" begin
+        w = Window(Dict(:show => false))
+        mounted = Channel(false)
+        setmounted = () -> push!(mounted, true)
+        scope = Scope()
+        onmount(scope, js"""
+            function () {
+                $setmounted()
+            }
+        """)
+        body!(w, scope)
+        did_mount = with_timeout(() -> take!(mounted), 5)
+        @test did_mount
+    end
+
+    @testset "button click" begin
+        w = Window(Dict(:show => false))
+        scope = Scope()
+        obs = Observable(scope, "obs", false)
+        obschannel = Channel(1)
+        on((x) -> push!(obschannel, x), obs)
+        scope(dom"button#mybutton"(
+            events=Dict(
+                "click" => @js function()
+                    $obs[] = true
+                end
+            )
+        ))
+        body!(w, scope)
+
+        # Sleep to allow WebIO scope to mount in Electron
+        sleep(0.25)
+
+        @js w document.querySelector("#mybutton").click()
+        did_click = with_timeout(() -> take!(obschannel), 5)
+        @test did_click
+    end
+end


### PR DESCRIPTION
I think the use of `Condition` over something like `Future` from `Distributed` (builtin package) was a mistake but trying to rectify that wouldn't be worth it right now (and I'm not sure that anyone else will agree with me on that haha).

Anyway, what this diff does:
* Makes `Window()` sync by default (so that anything you do with the resulting Window is safe).
* Adds `Base.wait(::Window)`. After this returns, the Window should be safe to do things to (e.g. `body!`).
* Window's that were initialized with a URL have no associated initialization and cannot be `wait`-ed (I'd rather raise an error that says what you're trying to do doesn't make sense than just silently allowing it).

If you try to do anything before `wait`ing the Window, I make no guarantees and I don't think Blink, in general, should try to do so.

In the future™, we should probably just remove the `async` keyword in favor of telling the consumer to do `windowtask = @async Window()`.

Ping @NHDaly.